### PR TITLE
Prevent default onChange event from being run on the "form" element

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -81,6 +81,7 @@ class Form extends Component {
       onSubmitFailure,
       initialValues,
       onValueChange,
+      onChange,
       ...rest
     } = this.props
     return (

--- a/tests/components/Form.spec.js
+++ b/tests/components/Form.spec.js
@@ -85,6 +85,21 @@ describe('Form', () => {
     expect(spy.args[0][0].values).to.deep.equal({ greeting: 'hello' });
   })
 
+  it('does not apply unnecessary props to the form element', () => {
+    const excludedProps = {
+      preSubmit: true,
+      getApi: () => {},
+      dontPreventDefault: true,
+      onSubmitFailure: true,
+      initialValues: true,
+      onValueChange: true,
+      onChange: () =>  {}
+    };
+    const wrapper = mount(<Form {...excludedProps}>{() => <Text field="greeting" />}</Form>);
+    const input = wrapper.find('form');
+    expect(input.props()).to.not.have.any.keys(...Object.keys(excludedProps));
+  })
+
   it('should call onValueChange function when value changes', () => {
     const spy = sandbox.spy();
     const wrapper = mount(<Form onValueChange={spy}>{() => <Text field="greeting" />}</Form>);


### PR DESCRIPTION
Closes https://github.com/joepuzzo/informed/issues/18

I'd prefer to write a test that checked if `onChange` was run more times than expected, but it didn't look like the onChange event was being run as I would have expected in the tests. If you have a better idea, let me know and I can update the test.