### PR TITLE
Expose field to component

### DIFF
--- a/src/components/Field.js
+++ b/src/components/Field.js
@@ -40,6 +40,7 @@ class Field extends PureComponent {
       ...rest
     } = this.props;
     const props = {
+      field,
       fieldApi,
       fieldState,
       forwardedRef: debug ? this.me : forwardedRef,

--- a/src/components/form-fields/Checkbox.js
+++ b/src/components/form-fields/Checkbox.js
@@ -12,12 +12,14 @@ const Checkbox = ( { fieldApi, fieldState, ...props  } ) => {
   const {
     onChange,
     onBlur,
+    field,
     forwardedRef,
     ...rest
   } = props
   return (
     <input
       {...rest}
+      name={field}
       ref={forwardedRef}
       checked={!!value}
       onChange={e => {

--- a/src/components/form-fields/Radio.js
+++ b/src/components/form-fields/Radio.js
@@ -15,12 +15,14 @@ const Radio = ( { radioGroupApi, radioGroupState, ...props  } ) => {
     value,
     onChange,
     onBlur,
+    field,
     forwardedRef,
     ...rest
   } = props
   return (
     <input
       {...rest}
+      name={field}
       ref={forwardedRef}
       value={value}
       checked={groupValue === value}

--- a/src/components/form-fields/Select.js
+++ b/src/components/form-fields/Select.js
@@ -32,6 +32,7 @@ class Select extends React.Component {
     const {
       onChange,
       onBlur,
+      field,
       forwardedRef,
       children,
       multiple,
@@ -41,6 +42,7 @@ class Select extends React.Component {
       <select
         {...rest}
         multiple={multiple}
+        name={field}
         ref="select"
         value={value || ( multiple ? [] : '' )}
         onChange={this.handleChange}

--- a/src/components/form-fields/Text.js
+++ b/src/components/form-fields/Text.js
@@ -12,12 +12,14 @@ const Text = ( { fieldApi, fieldState, ...props  } ) => {
   const {
     onChange,
     onBlur,
+    field,
     forwardedRef,
     ...rest
   } = props
   return (
     <input
         {...rest}
+        name={field}
         ref={forwardedRef}
         value={!value && value !== 0 ? '' : value}
         onChange={e => {

--- a/src/components/form-fields/TextArea.js
+++ b/src/components/form-fields/TextArea.js
@@ -12,12 +12,14 @@ const TextArea = ( { fieldApi, fieldState, ...props  } ) => {
   const {
     onChange,
     onBlur,
+    field,
     forwardedRef,
     ...rest
   } = props
   return (
     <textarea
         {...rest}
+        name={field}
         ref={forwardedRef}
         value={!value ? '' : value}
         onChange={e => {


### PR DESCRIPTION
This PR implements a fix for the [problem mentioned here](https://github.com/joepuzzo/informed/issues/9#issuecomment-400356467) by exposing the input name (the `field` prop) to the underlying input.

The underlying use-case is implemented in the second (optional) commit, filling in the html `name` prop to enable the generation of (more) valid/complete forms.