### PR TITLE
Adding form API fieldExists method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1585,7 +1585,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {

--- a/src/Controller/FormController.js
+++ b/src/Controller/FormController.js
@@ -26,7 +26,8 @@ class FormController extends EventEmitter {
       setState: this.setFormState,
       setValues: this.setValues,
       reset: this.reset,
-      notify: this.notify
+      notify: this.notify,
+      fieldExists: this.fieldExists
     }
     this.fields = new Map();
     this.validationPromiseIDs = new Map();
@@ -227,6 +228,10 @@ class FormController extends EventEmitter {
     });
     this.emit('change', this.state);
     this.emit('update', this.state);
+  }
+
+  fieldExists = (field) => {
+    return !!this.fields.get(field);
   }
 
   notify = ( fields ) => {

--- a/stories/Form/Api/README.md
+++ b/stories/Form/Api/README.md
@@ -17,6 +17,7 @@ This api allows you to grab and manipulate values using getters and setters. Bel
 | getState    | `getState()`                                | Function that returns the formState. Note this will only return the state as it existed when the function was called.
 | setValues   | `setValues({ greeting: 'hello'})`           | Function that will set the form values.
 | reset   | `reset()`                                       | Function that will reset the form to its initial state.
+| fieldExists   | `fieldExists('greeting')`                 | Function that will return true when the field exists on the form.
 
 
 **"Ok so informed gives us access to this formApi.. but how do i get my hands

--- a/tests/Controller.spec.js
+++ b/tests/Controller.spec.js
@@ -249,6 +249,28 @@ describe('Controller', () => {
 
     });
 
+    describe('fieldExists', () => {
+
+      it('should return true when field exists', () => {
+        const controller = new Controller();
+        const expected =  { greeting: 'hello' }
+        controller.register( 'greeting', getFieldController('greeting', controller.api) )
+        const result = controller.api.fieldExists('greeting');
+        expect(result).to.be.true;
+      });
+
+      it('should return false when field does not exist', () => {
+        const controller = new Controller();
+        const expected =  { greeting: 'hello' }
+        controller.register( 'greeting', getFieldController('greeting', controller.api) )
+        const result = controller.api.fieldExists('notgreeting');
+        expect(result).to.be.false;
+      });
+
+    });
+
+
+
     describe('setTouched', () => {
 
       it('should set the form touched', () => {

--- a/tests/components/Form.spec.js
+++ b/tests/components/Form.spec.js
@@ -366,6 +366,26 @@ describe('Form', () => {
     expect(api.getState().values).to.deep.equal({ greeting: 'hello' })
   })
 
+  it('fieldExists should return true when field exists', () => {
+    let api
+    const setApi = param => {
+      api = param
+    }
+    mount(<Form getApi={setApi}>{() => <Text field="greeting" />}</Form>)
+    const result = api.fieldExists('greeting');
+    expect(result).to.be.true;
+  })
+
+  it('fieldExists should return false when field does not exists', () => {
+    let api
+    const setApi = param => {
+      api = param
+    }
+    mount(<Form getApi={setApi}>{() => <Text field="greeting" />}</Form>)
+    const result = api.fieldExists('notgreeting');
+    expect(result).to.be.false;
+  })
+
   it('reset should reset the form to its initial state', () => {
     let api
     const setApi = param => {


### PR DESCRIPTION
This adds a new method on the form API to test the presence of a field on the form.  This is useful when dynamically adding/removing fields from the form.