### PR TITLE
Let bindToField pass field prop

### DIFF
--- a/src/HOC/withFieldStuff.js
+++ b/src/HOC/withFieldStuff.js
@@ -144,7 +144,6 @@ const bindToField = ( Component ) => withController(withFormApi(
     render(){
       const {
         mask,
-        field,
         formApi,
         formState,
         controller,

--- a/src/components/Field.js
+++ b/src/components/Field.js
@@ -32,7 +32,6 @@ class Field extends PureComponent {
       children,
       component,
       render,
-      field,
       register,
       deregister,
       forwardedRef,
@@ -40,7 +39,6 @@ class Field extends PureComponent {
       ...rest
     } = this.props;
     const props = {
-      field,
       fieldApi,
       fieldState,
       forwardedRef: debug ? this.me : forwardedRef,

--- a/tests/components/form-fields/Text.spec.js
+++ b/tests/components/form-fields/Text.spec.js
@@ -50,6 +50,15 @@ describe('Text', () => {
     expect(spy.called).to.equal(true);
   });
 
+  it('should expose the field name', () => {
+    const wrapper = mount(
+      <Form getApi={() => {}}>
+        <Text field="greeting" />
+      </Form>
+    )
+    expect(wrapper.find('input').prop('name')).to.equal('greeting');
+  });
+
   it('should run mask when user types in text input and mask is passed', () => {
     let savedApi;
     const mask = value => (`${value}!`);


### PR DESCRIPTION
T'was late in the afternoon. Since the `field` prop was declared, I assumed it to be passed through, but it was also filtered in `bindToField`, so the fix of the previous PR was broken.

This fixes the bug and includes an additional test case to ensure behaviour.