### PR TITLE
React should be a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,9 @@
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0-rc.1"
   },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "nyc": {
     "instrument": false,
     "sourceMap": false,


### PR DESCRIPTION
It's kinda dumb, because who's going to install this library and not already have React installed, but it's more correct this way.

Nice lib, btw. 👍 