### PR TITLE
Remove hardcoded value and use forwardedRef instead.

### DIFF
--- a/src/components/form-fields/Select.js
+++ b/src/components/form-fields/Select.js
@@ -40,7 +40,7 @@ class Select extends React.Component {
         {...rest}
         multiple={multiple}
         name={field}
-        ref="select"
+        ref={forwardedRef}
         value={value || (multiple ? [] : '')}
         onChange={this.handleChange}
         onBlur={e => {


### PR DESCRIPTION
### What

* Fixed incorrect ref for `<Select>` Element

### Why
Because I created test enviorement to create solutions to existing Issues. I used create-react-app to save some time. But When I tried to use `<Select>` I couldn't. Interesting thing is that it doesn't happen on  https://stackblitz.com/edit/react-informed
![image](https://user-images.githubusercontent.com/12088647/44981430-cae5f200-af72-11e8-90ec-407ff2e4b268.png)


Code that caused this error:
```javascript
class App extends Component {
  validate = (data) => {
    console.log('validate',{data})
    
    return null
  }

  onPreSubmit = (data) => {
    console.log('onPreSubmit',{data})
    return {
      a: 'b'
    }
  }

  render() {
    return (
      <div>
        <Form preSubmit={this.onPreSubmit} onSubmit={data => console.log('ON SUBMIT', { data })} id="simple-form">
          {
            formApi => {

              return (
                <div>
                  <label htmlFor="name-field">First name:</label>
                  <Text initialValue="daniel" validate={this.validate} field="first-name" id="name-field" />
                  <Text validate={this.validate} field="last-name" id="name-field" />
                  <Select field="status" id="select-status">
                  </Select>
                  <button type="submit">
                    Submit
                </button>
                </div>
              )
            }
          }
        </Form>

      </div>
    );
  }
}

export default App;

```