### PR TITLE
Only run async validators when they are defined

### DIFF
--- a/src/Controller/FieldController.js
+++ b/src/Controller/FieldController.js
@@ -14,6 +14,9 @@ class FieldController {
       return this.config.asyncValidate(this.api.getValue(), values);
     }
   }
+  shouldValidateAsync() {
+      return !!this.config.asyncValidate;
+  }
   updateConfig(config) {
     this.config = config;
   }

--- a/src/Controller/FormController.js
+++ b/src/Controller/FormController.js
@@ -276,8 +276,8 @@ class FormController extends EventEmitter {
       // Validate
       //debugger
       this.errors.set(field, fieldController.validate(this.state.values));
-      // Build up list of async validatiors
-      if (fieldController.asyncValidate) {
+      // Build up list of async validators
+      if (fieldController.shouldValidateAsync()) {
         // Only validate if sync is valid
         if (!this.errors.get(field)) {
           asyncValidators.push(() =>


### PR DESCRIPTION
I was building a new `Form` with more than 20 fields (I am using `Scope` for some of them) and noticed that submitting it was taking more than 5 seconds and the entire UI was hanging.

Digging a bit deeper in the code I noticed that the `FormController`'s `validateAsync` function was being executed for every field even if the `asyncValidate` prop was not being passed to the `Field`.

So I created a new function on the `FieldController` class to check if the async validators are defined.

I might be missing something here but once I did this I got a speed up of almost 80% when submitting the form.