### PR TITLE
Updated Changelog with note about validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - the field `"siblings.1"` now resolves to `values.siblings[1]`, it used to resolve to `values.siblings.1`
 - the field `"siblings['2']"` now resolves to `values.siblings[2]`, it used to resolve to `values.siblings.2`
 - withFormApi will no longer trigger a rerender if the fomrs state changes. This is a great optimization for those who want to modify but dont care about the form state!
+- the `validate` prop now expects the validation function to return `undefined` if there is no error. Any other returned value (including falsey `null`, `0`, etc will be treated as an error for the field.
 
 ### Removed
 


### PR DESCRIPTION
Resolves #139 by noting the change to `validate` as a breaking change.
* Makes clear that `undefined` is how to avoid marking a field as having an error
* Makes clear that falsey (`null`, `0`, `''`, etc) also now flag a field as having an error