### PR TITLE
Add support for formState.initial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@
 
 ## 2.1.6 (Feb 21, 2019)
 
-### Updated 
+### Updated
 - typing files for type script users
 
 ## 2.1.5 (Feb 19, 2019)
 
-### Fixed 
+### Fixed
 - Issue with text area input not setting typed value
 
 ## 2.1.4 (Feb 19, 2019)

--- a/src/FormController.js
+++ b/src/FormController.js
@@ -26,6 +26,7 @@ class FormController extends EventEmitter {
       errors: {},
       pristine: true,
       dirty: false,
+      initial: false,
       invalid: false,
       submits: 0
     };
@@ -58,6 +59,7 @@ class FormController extends EventEmitter {
       ...this.state, 
       pristine: this.pristine(),
       dirty: this.dirty(),
+      initial: this.initial(),
       invalid: this.invalid()
     };
   }
@@ -195,6 +197,10 @@ class FormController extends EventEmitter {
 
   getInitialValue( field ){
     return ObjectMap.get(this.options.initialValues, field);
+  }
+  
+  initial() {
+    return ObjectMap.equal(this.options.initialValues || {}, this.state.values);
   }
 
   reset() {

--- a/src/ObjectMap.js
+++ b/src/ObjectMap.js
@@ -6,6 +6,7 @@ import ldhas from 'lodash/has';
 import ldvalues from 'lodash/values';
 import ldpullAt from 'lodash/pullAt';
 import ldpull from 'lodash/pull';
+import ldequal from 'lodash/isEqual';
 import Debug from 'debug';
 const debug = Debug('informed:ObjMap' + '\t');
 
@@ -17,6 +18,10 @@ const pathToArrayElem = (path) => {
 class ObjectMap {
   static empty(object) {
     return ldvalues(object).length === 0;
+  }
+
+  static equal(object, compareTo) {
+    return ldequal(object, compareTo);
   }
 
   static get(object, path) {

--- a/src/hooks/useField.js
+++ b/src/hooks/useField.js
@@ -53,6 +53,11 @@ function useField(field, fieldProps = {}) {
   // Grab the form state
   const formApi = useFormApi();
 
+  /* ---------------------- Getters ---------------------- */
+  const getInitial = () => {
+    return (initialValue !== null) ? initialValue === getVal() : true;
+  };
+
   /* ---------------------- Setters ---------------------- */
 
   // Define set error
@@ -155,6 +160,7 @@ function useField(field, fieldProps = {}) {
     setValue,
     setTouched,
     setError,
+    getInitial,
     reset, 
     validate: fieldValidate
   };
@@ -164,7 +170,8 @@ function useField(field, fieldProps = {}) {
     value,
     error,
     touched,
-    maskedValue
+    maskedValue,
+    initial: getInitial()
   };
 
   logger('Render', formApi.getFullField(field), fieldState);

--- a/src/hooks/useField.js
+++ b/src/hooks/useField.js
@@ -55,7 +55,7 @@ function useField(field, fieldProps = {}) {
 
   /* ---------------------- Getters ---------------------- */
   const getInitial = () => {
-    return (initialValue !== null) ? initialValue === getVal() : true;
+    return (initialValue !== null && typeof initialValue !== 'undefined') ? initialValue === getVal() : true;
   };
 
   /* ---------------------- Setters ---------------------- */

--- a/src/hooks/useFieldApi.js
+++ b/src/hooks/useFieldApi.js
@@ -9,6 +9,7 @@ const buildFieldApi = (formApi, field) => {
     setTouched: value => formApi.setTouched(field, value),
     getError: () => formApi.getError(field),
     setError: value => formApi.setError(field, value),
+    getInitial: () => formApi.getInitial(field),
   };
 };
 

--- a/src/hooks/useFieldState.js
+++ b/src/hooks/useFieldState.js
@@ -7,6 +7,7 @@ const buildFieldState = (fieldApi) => {
     value: fieldApi.getValue(),
     touched: fieldApi.getTouched(),
     error: fieldApi.getError(),
+    initial: fieldApi.getInitial()
   };
 };
 


### PR DESCRIPTION
After discussion in #138, this is a PR that adds support for determining if the current form values have deviated from their initial values. The original idea was to use `formState.hasChanged`, but `informed` uses single-word phrases to describe the form state. The resulting proposal is the `initial` prop.

| Attribute    | Example    | Initial Value    | Derived    | Description    |
|---|---|---|---|---|
| initial | `true` | `true` | YES | Boolean that is true when the form's values match the initial values provided |