### PR TITLE
Fixing type for ref field on FieldContext

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,7 +75,7 @@ declare module 'informed' {
     fieldApi: FieldApi<V>
     // not sure what this is for, I actually found it in https://github.com/joepuzzo/informed/blob/02584aeb10bbf04875bddc974f62db95c5612f57/src/hooks/useField.js#L205, not in the docs
     purify: <T>(children: T, userProps?: any[]) => T
-    ref: React.RefObject
+    ref: React.RefObject<HTMLInputElement>
   }
 
   export interface BaseFieldProps<V = FormValue, VS = FormValues>


### PR DESCRIPTION
Looks like there was a little issue with the typings for FieldContext.