### PR TITLE
Allowing for optional generic on FormValue

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ import React from 'react'
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
 declare module 'informed' {
-  export type FormValue = string | number | boolean
+  export type FormValue<T = {}> = string | number | boolean | T
   export interface FormValues {
     [key: string]: FormValue
   }


### PR DESCRIPTION
Currently, FormValue only allowed for string, number, or boolean types.  This update will allow for FormValue to be generic, so consumers can store any type as a FormValue.