### PR TITLE
Added component display name to asField HOC for better debugging

### DIFF
--- a/src/HOC/asField.js
+++ b/src/HOC/asField.js
@@ -1,59 +1,66 @@
 import React from 'react';
 import useField from '../hooks/useField';
 
-const asField = Component => props => {
-  const { 
-    field, 
-    validate, 
-    initialValue, 
-    validateOnChange, 
-    validateOnBlur,
-    validateOnMount,
-    maskOnBlur,
-    allowEmptyString,
-    onValueChange,
-    notify,
-    keepState,
-    maintainCursor,
-    debug,
-    type,
-    mask,
-    format,
-    parse,
-    ...rest } = props;
-  const fieldProps = {
-    validate,
-    initialValue, 
-    validateOnChange, 
-    validateOnBlur,
-    onValueChange,
-    validateOnMount,
-    maskOnBlur,
-    allowEmptyString,
-    notify,
-    keepState,
-    maintainCursor,
-    debug,
-    type,
-    mask,
-    format,
-    parse
-  };
+const asField = Component => {
+  const displayName = `asField(${Component.displayName || Component.name})`;
 
-  const { fieldState, fieldApi, purify, ref } = useField(field, fieldProps);
-   
-  return purify(
-    <Component
-      fieldApi={fieldApi}
-      fieldState={fieldState}
-      field={field}
-      forwardedRef={ref}
-      debug={debug}
-      type={type}
-      {...rest}
-    />, 
-    Object.values(rest)
-  );
+  const C = props => {
+    const {
+      field,
+      validate,
+      initialValue,
+      validateOnChange,
+      validateOnBlur,
+      validateOnMount,
+      maskOnBlur,
+      allowEmptyString,
+      onValueChange,
+      notify,
+      keepState,
+      maintainCursor,
+      debug,
+      type,
+      mask,
+      format,
+      parse,
+      ...rest } = props;
+    const fieldProps = {
+      validate,
+      initialValue,
+      validateOnChange,
+      validateOnBlur,
+      onValueChange,
+      validateOnMount,
+      maskOnBlur,
+      allowEmptyString,
+      notify,
+      keepState,
+      maintainCursor,
+      debug,
+      type,
+      mask,
+      format,
+      parse
+    };
+
+    const { fieldState, fieldApi, purify, ref } = useField(field, fieldProps);
+
+    return purify(
+      <Component
+        fieldApi={fieldApi}
+        fieldState={fieldState}
+        field={field}
+        forwardedRef={ref}
+        debug={debug}
+        type={type}
+        {...rest}
+      />,
+      Object.values(rest)
+    );
+  };
+  C.displayName = displayName;
+
+  return C;
 };
 
 export default asField;


### PR DESCRIPTION
During debugging, I was having some issues identifying an ordering issue with composed HOC.

I've added the components display name (as per React's suggestion) to the wrapper for `asField`.