### PR TITLE
Added effect to update formOptions ( validateFields, preventEnter, etc ) when props changes

### DIFF
--- a/src/FormController.js
+++ b/src/FormController.js
@@ -59,6 +59,10 @@ class FormController extends EventEmitter {
     };
   }
 
+  setOptions(options) {
+    this.options = options;
+  }
+
   // Generate the external form state that will be exposed to the users
   getFormState() {
     return {

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useLayoutEffect } from 'react';
+import React, { useState, useLayoutEffect, useEffect, useMemo } from 'react';
 import Debug from '../debug';
 import FormController from '../FormController';
 
@@ -20,18 +20,24 @@ const useForm = ({
 
   debug('Render useForm');
 
-  // Create form controller
-  const [formController] = useState(new FormController({
+  const formControllerOptions = useMemo(()=>({
     dontPreventDefault,
     initialValues,
     validate,
     validateFields,
     allowEmptyStrings,
     preventEnter,
-  }));
+  }), [dontPreventDefault, initialValues, validate, validateFields, allowEmptyStrings, preventEnter]);
+
+  // Create form controller
+  const [formController] = useState(()=> new FormController(formControllerOptions));
+
+  useEffect(()=>{
+    formController.setOptions(formControllerOptions);
+  }, [formControllerOptions]);
 
   // Form state will be used to trigger rerenders
-  const [ formState, setFormState ] = useState( formController.getFormState() );
+  const [ formState, setFormState ] = useState( ()=> formController.getFormState() );
 
   // Register for events
   useLayoutEffect(()=>{
@@ -68,7 +74,7 @@ const useForm = ({
   });
 
   // We dont want this to happen on every render so thats why useState is used here
-  const [ formApi ] = useState( formController.getFormApi() );
+  const [ formApi ] = useState( ()=> formController.getFormApi() );
 
   return { formApi, formState, formController };
 };

--- a/tests/components/Form.spec.js
+++ b/tests/components/Form.spec.js
@@ -285,6 +285,28 @@ describe('Form', () => {
     expect(spy.args[0][0]).to.deep.equal({ greeting: 'hello' });
   });
 
+  it('should update validateFields function when the validateFields prop changes', () => {
+    const dummy1 = sandbox.spy();
+    const dummy2 = sandbox.spy();
+    const spy = sandbox.spy();
+    const wrapper = mount(
+      <Form validateFields={dummy1}>
+        <Text field="greeting" />
+        <button type="submit">Submit</button>
+      </Form>
+    );
+    wrapper.setProps({validateFields: dummy2});
+    const input = wrapper.find('input');
+    input.simulate('change', { target: { value: 'hello' } });
+    wrapper.setProps({validateFields: spy});
+    const button = wrapper.find('button');
+    button.simulate('submit');
+    expect(dummy1.called).to.equal(false);
+    expect(dummy2.called).to.equal(false);
+    expect(spy.called).to.equal(true);
+    expect(spy.args[0][0]).to.deep.equal({ greeting: 'hello' });
+  });
+
   it('should set correct errors when invalid form level field validation', () => {
     const spy = sandbox.spy();
     let api;


### PR DESCRIPTION
Update `FormController` options when those changes (ie. `Form` props changes).

This is related to #196 

I also changed the `useState` initial values to a [lazy initialisation ](https://reactjs.org/docs/hooks-reference.html#lazy-initial-state) in `hooks/useForm.js` . That way the `FormController` is only created once.



