### PR TITLE
Bold Code Font Hard to Read in Firefox

### DIFF
--- a/.storybook/assets/styles.css
+++ b/.storybook/assets/styles.css
@@ -31,6 +31,5 @@ hr {
 }
 
 pre {
-  font-weight: bold;
   font-size:  1em !important;
 }


### PR DESCRIPTION
The extra `pre { font-weight: bold }` makes code examples very difficult to read in Firefox, due to text appearing as fuzzy.

With bold:
![Screen Shot 2019-06-24 at 10 34 41 AM](https://user-images.githubusercontent.com/3778552/60039585-ea6a1a80-966b-11e9-8743-86c3da19a81b.png)

Without bold:
![Screen Shot 2019-06-24 at 10 35 03 AM](https://user-images.githubusercontent.com/3778552/60039582-e807c080-966b-11e9-8fb6-3808efb741ef.png)


