### PR TITLE
Add allowEmptyStrings to Form's TS props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -111,6 +111,7 @@ declare module 'informed' {
    */
 
   export interface BasicFormProps<V = FormValues> {
+    allowEmptyStrings?: boolean
     onSubmit?: (values: V) => void
     preSubmit?: (values: V) => V
     initialValues?: V


### PR DESCRIPTION
`allowEmptyStrings` was missing from the TypeScript definitions, so I've added it.