### PR TITLE
Added an error message when contexts are undefined

### DIFF
--- a/src/hooks/useField.js
+++ b/src/hooks/useField.js
@@ -56,6 +56,10 @@ function useField(fieldProps = {}, userRef) {
   // Grab the form state
   const formApi = useFormApi();
 
+  if (!updater || !formApi) {
+    throw new Error('FormContext is not defined. Have you initialized a Form component higher in the tree?');
+  }
+
   // Initialize state 
   const [value, setVal, getVal] = useStateWithGetter(initializeValue(initialValue, mask));
   const [error, setErr, getErr] = useStateWithGetter( validateOnMount ? validate(value) : undefined );


### PR DESCRIPTION
I've added a little error message for the case if someone didn't initialize the Form before calling one of the field components.

It has happened to me that I would just miss it by mistake and the error message only says that some specific variable is `undefined`. Now it checks for that and tells you that you need to initialize it yourself.