### PR TITLE
fix(index.d.ts): add missing setFormError prop to FormApi interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,7 @@ declare module 'informed' {
     getTouched: (name: string) => boolean
     setError: (name: string, error: FormError) => void
     getError: (name: string) => FormError
+    setFormError: (error: FormError) => void
     getState: () => FormState<V>
     reset: () => void
     setValues: (values: V) => void


### PR DESCRIPTION
Until this is merged, one can augment the existing `FormApi` interface:

```javascript
// src/typings/informed/index.d.ts
import {FormApi, FormError} from 'informed';

declare module 'informed' {
  interface FormApi {
    setFormError: (error: FormError) => void;
  }
}
```