### PR TITLE
Update useField to trigger validation when validation related props change

### DIFF
--- a/src/hooks/useField.js
+++ b/src/hooks/useField.js
@@ -4,23 +4,23 @@ import useFormApi from './useFormApi';
 import useStateWithGetter from './useStateWithGetter';
 import Debug from '../debug';
 import useLayoutEffect from './useIsomorphicLayoutEffect';
-const logger = Debug('informed:useField'+ '\t');
+const logger = Debug('informed:useField' + '\t');
 
 const initializeValue = (value, mask) => {
-  if(value != null){
+  if (value != null) {
     // Call mask if it was passed
-    if(mask){
+    if (mask) {
       return mask(value);
     }
     return value;
   }
   // Not needed but called out specifically
   return undefined;
-}; 
+};
 
 const initializeMask = (value, format, parse) => {
   // Call format and parse if they were passed
-  if(format && parse){
+  if (format && parse) {
     return format(value);
   }
   return value;
@@ -28,7 +28,7 @@ const initializeMask = (value, format, parse) => {
 
 function useField(fieldProps = {}, userRef) {
   // Pull props off of field props
-  const { 
+  const {
     field,
     validate,
     mask,
@@ -43,10 +43,10 @@ function useField(fieldProps = {}, userRef) {
     allowEmptyString,
     onValueChange,
     notify,
-    keepState, 
+    keepState,
     maintainCursor,
     debug,
-    shadow, 
+    shadow,
     ...userProps
   } = fieldProps;
 
@@ -56,13 +56,21 @@ function useField(fieldProps = {}, userRef) {
   // Grab the form state
   const formApi = useFormApi();
 
-  // Initialize state 
-  const [value, setVal, getVal] = useStateWithGetter(initializeValue(initialValue, mask));
-  const [error, setErr, getErr] = useStateWithGetter( validateOnMount ? validate(value) : undefined );
+  // Initialize state
+  const [value, setVal, getVal] = useStateWithGetter(
+    initializeValue(initialValue, mask)
+  );
+  const [error, setErr, getErr] = useStateWithGetter(
+    validateOnMount ? validate(value) : undefined
+  );
   const [touched, setTouch, getTouch] = useStateWithGetter();
   const [cursor, setCursor, getCursor] = useStateWithGetter(0);
-  const [cursorOffset, setCursorOffset, getCursorOffset] = useStateWithGetter(0);
-  const [maskedValue, setMaskedValue ] = useState(initializeMask(value, format, parse));
+  const [cursorOffset, setCursorOffset, getCursorOffset] = useStateWithGetter(
+    0
+  );
+  const [maskedValue, setMaskedValue] = useState(
+    initializeMask(value, format, parse)
+  );
 
   // Create then update refs to props
   const initialValueRef = useRef(initialValue);
@@ -71,7 +79,7 @@ function useField(fieldProps = {}, userRef) {
   /* ---------------------- Setters ---------------------- */
 
   // Define set error
-  const setError = (val) => { 
+  const setError = val => {
     logger(`Setting ${field}'s error to ${val}`);
     setErr(val);
     updater.setError(field, val);
@@ -79,7 +87,6 @@ function useField(fieldProps = {}, userRef) {
 
   // Define set value
   const setValue = (val, e, options = {}) => {
-
     const formOptions = formApi.getOptions();
 
     logger(`Setting ${field} to ${val}`);
@@ -87,38 +94,43 @@ function useField(fieldProps = {}, userRef) {
     let maskedVal = val;
     // Set value to undefined if its an empty string
 
-    if( val === '' && !allowEmptyString && !options.allowEmptyString && !formOptions.allowEmptyStrings ){
+    if (
+      val === '' &&
+      !allowEmptyString &&
+      !options.allowEmptyString &&
+      !formOptions.allowEmptyStrings
+    ) {
       val = undefined;
     }
     // Turn string into number for number fields
-    if(fieldProps.type === 'number' && val !== undefined ){
+    if (fieldProps.type === 'number' && val !== undefined) {
       val = +val;
     }
     // Call mask if it was passed
-    if(mask && !maskOnBlur){
+    if (mask && !maskOnBlur) {
       maskedVal = mask(val);
       val = mask(val);
     }
     // Call maskWithCursorOffset if it was passed
-    if(maskWithCursorOffset && !maskOnBlur){
+    if (maskWithCursorOffset && !maskOnBlur) {
       const res = maskWithCursorOffset(val);
       maskedVal = res.value;
       val = res.value;
       setCursorOffset(res.offset);
     }
     // Call format and parse if they were passed
-    if(format && parse){
+    if (format && parse) {
       val = parse(val);
       maskedVal = format(val);
     }
     // We only need to call validate if the user gave us one
     // and they want us to validate on change && its not the initial validation
-    if (validate && validateOnChange && !options.initial ) {
+    if (validate && validateOnChange && !options.initial) {
       logger(`Validating after change ${field} ${val}`);
       setError(validate(val, formApi.getValues()));
     }
     // Remember Cursor position!
-    if(e && e.target && e.target.selectionStart ){
+    if (e && e.target && e.target.selectionStart) {
       setCursor(e.target.selectionStart);
     }
 
@@ -126,45 +138,45 @@ function useField(fieldProps = {}, userRef) {
     setVal(val);
     setMaskedValue(maskedVal);
     // If the user passed in onValueChange then call it!
-    if( onValueChange ){
+    if (onValueChange) {
       onValueChange(val);
-    }    
+    }
     // Call the updater
     updater.setValue(field, val);
   };
 
   // Define set touched
-  const setTouched = ( val, reset ) => {
+  const setTouched = (val, reset) => {
     // We only need to call validate if the user gave us one
     // and they want us to validate on blur
-    if (validate && validateOnBlur && !reset && val ) {
+    if (validate && validateOnBlur && !reset && val) {
       logger(`Validating after blur ${field} ${getVal()}`);
       setError(validate(getVal(), formApi.getValues()));
     }
     // Call mask if it was passed
-    if(mask && maskOnBlur){
-      const maskedVal = mask( getVal() );
+    if (mask && maskOnBlur) {
+      const maskedVal = mask(getVal());
       // Now we update the value
       setVal(maskedVal);
       setMaskedValue(maskedVal);
       // If the user passed in onValueChange then call it!
-      if( onValueChange ){
+      if (onValueChange) {
         onValueChange(maskedVal);
-      }    
+      }
       // Call the updater
       updater.setValue(field, maskedVal);
     }
     // Call maskWithCursorOffset if it was passed
-    if(maskWithCursorOffset && maskOnBlur){
+    if (maskWithCursorOffset && maskOnBlur) {
       const res = maskWithCursorOffset(getVal());
       setCursorOffset(res.offset);
       // Now we update the value
       setVal(res.value);
       setMaskedValue(res.value);
       // If the user passed in onValueChange then call it!
-      if( onValueChange ){
+      if (onValueChange) {
         onValueChange(res.value);
-      }    
+      }
       // Call the updater
       updater.setValue(field, res.value);
     }
@@ -177,14 +189,14 @@ function useField(fieldProps = {}, userRef) {
     const initVal = initializeValue(initialValueRef.current, mask);
     // TODO support numbers
     setValue(initialValueRef.current);
-    // Setting somthing to undefined will remove it 
+    // Setting somthing to undefined will remove it
     setError(validateOnMount ? validate(initVal) : undefined);
     setTouched(undefined, true);
   };
 
   // Define validate
-  const fieldValidate = ( override ) => {
-    if( validate ){
+  const fieldValidate = override => {
+    if (validate) {
       logger(`Field validating ${field} ${getVal() || override}`);
       setError(validate(getVal() || override, formApi.getValues()));
     }
@@ -197,10 +209,10 @@ function useField(fieldProps = {}, userRef) {
     setValue,
     setTouched,
     setError,
-    reset, 
-    validate: fieldValidate, 
+    reset,
+    validate: fieldValidate,
     getValue: getVal,
-    getTouched: getTouch, 
+    getTouched: getTouch,
     getError: getErr
   };
 
@@ -213,18 +225,25 @@ function useField(fieldProps = {}, userRef) {
   };
 
   // Create shadow state if this is a shadow field
-  if( shadow ){
+  if (shadow) {
     fieldState = {
       error,
-      touched,
+      touched
     };
   }
 
   // Initial register needs to happen before render ( simulating constructor muhahahah )
-  useState(()=> {
+  useState(() => {
     const fullField = formApi.getFullField(field);
     logger('Initial Register', fullField);
-    updater.register(field, fieldState, { field: fullField, fieldApi, fieldState, notify, keepState, shadow });
+    updater.register(field, fieldState, {
+      field: fullField,
+      fieldApi,
+      fieldState,
+      notify,
+      keepState,
+      shadow
+    });
   });
 
   logger('Render', formApi.getFullField(field), fieldState);
@@ -238,7 +257,14 @@ function useField(fieldProps = {}, userRef) {
     () => {
       const fullField = formApi.getFullField(field);
       logger('Register', fullField);
-      updater.register(field, fieldState, { field: fullField, fieldApi, fieldState, notify, keepState, shadow });
+      updater.register(field, fieldState, {
+        field: fullField,
+        fieldApi,
+        fieldState,
+        notify,
+        keepState,
+        shadow
+      });
 
       return () => {
         logger('Deregister', fullField);
@@ -254,7 +280,23 @@ function useField(fieldProps = {}, userRef) {
     () => {
       const fullField = formApi.getFullField(field);
       logger('Update', field);
-      updater.update(field, { field: fullField, fieldApi, fieldState, notify, keepState, shadow });
+      updater.update(field, {
+        field: fullField,
+        fieldApi,
+        fieldState,
+        notify,
+        keepState,
+        shadow
+      });
+
+      // Should re-trigger validation if validation handler updates
+      const val = getVal();
+      if (
+        validate &&
+        ((validateOnChange && val) || (validateOnBlur && getTouch()))
+      ) {
+        setError(validate(val, formApi.getValues()));
+      }
     },
     // This is VERYYYY!! Important!
     [validate, validateOnChange, validateOnBlur, onValueChange]
@@ -263,33 +305,35 @@ function useField(fieldProps = {}, userRef) {
   // Maintain cursor position
   useLayoutEffect(
     () => {
-      if ( maintainCursor && ref.current != null && getCursor()) ref.current.selectionEnd = getCursor() + getCursorOffset();
+      if (maintainCursor && ref.current != null && getCursor())
+        ref.current.selectionEnd = getCursor() + getCursorOffset();
     },
     [value]
   );
 
   // for debugging
-  useLayoutEffect(
-    () => {
-      if (debug && ref) {
-        ref.current.style.border = '5px solid orange';
-        setTimeout(() => {
-          ref.current.style.borderWidth ='2px';
-          ref.current.style.borderStyle = 'inset';
-          ref.current.style.borderColor = 'initial';
-          ref.current.style.borderImage = 'initial';
-        }, 500);
-      }
+  useLayoutEffect(() => {
+    if (debug && ref) {
+      ref.current.style.border = '5px solid orange';
+      setTimeout(() => {
+        ref.current.style.borderWidth = '2px';
+        ref.current.style.borderStyle = 'inset';
+        ref.current.style.borderColor = 'initial';
+        ref.current.style.borderImage = 'initial';
+      }, 500);
     }
-  );
+  });
 
   // This is an awesome optimization!!
-  const shouldUpdate = [ ...Object.values(fieldState), ...Object.values(fieldProps), ...Object.values(userProps) ];
+  const shouldUpdate = [
+    ...Object.values(fieldState),
+    ...Object.values(fieldProps),
+    ...Object.values(userProps)
+  ];
 
-  const render = (children) => useMemo(() => children, [ ...shouldUpdate ]);
+  const render = children => useMemo(() => children, [...shouldUpdate]);
 
   return { fieldState, fieldApi, render, ref, userProps };
-
 }
 
 export default useField;


### PR DESCRIPTION
Looks like the majority of these changes were related to your prettier/eslintrc.

### Justification
If a user updates their `validate` function (in my case due to i18n support), `useField` should trigger validation if the necessary parameters are met.

Currently, `validate` can return a `ReactNode`, but in the case of wanting to return a string (in my case to be leveraged in an `aria-live` region), it's useful to update the validate function vs. using a `ReactNode` which will re-render on it's own within the component life-cycle.

